### PR TITLE
take as server name env.host for non-production deployments

### DIFF
--- a/appconfig/templates/nginx-app.conf
+++ b/appconfig/templates/nginx-app.conf
@@ -24,7 +24,11 @@ server {
     {%- endif %}
 
 server {
-    server_name {{ app.domain }};
+    {%- if env.environment == 'production' %}
+        server_name  {{ app.domain }};
+    {%- else %}
+        server_name  {{ env.host }};
+    {%- endif %}
 
     {%- if env.environment == 'production' %}
         listen 443 ssl;


### PR DESCRIPTION
this makes testing and staging easier